### PR TITLE
RDKEMW-4012: Remove-getEdid2AllmSupport-From-HAL

### DIFF
--- a/ds/hdmiIn.cpp
+++ b/ds/hdmiIn.cpp
@@ -67,6 +67,7 @@
 #include "edid-parser.hpp"
 #include "dsInternal.h"
 
+
 namespace device 
 {
 

--- a/ds/hdmiIn.cpp
+++ b/ds/hdmiIn.cpp
@@ -65,7 +65,7 @@
 #include "dsHdmiIn.h"
 #include "dsUtl.h"
 #include "edid-parser.hpp"
-
+#include "dsInternal.h"
 
 namespace device 
 {

--- a/rpc/cli/dsHdmiIn.c
+++ b/rpc/cli/dsHdmiIn.c
@@ -54,6 +54,7 @@
 #include "libIARM.h"
 #include "libIBus.h"
 #include "safec_lib.h" 
+#include "dsInternal.h"
 
 
 dsError_t dsHdmiInInit (void)

--- a/rpc/include/dsInternal.h
+++ b/rpc/include/dsInternal.h
@@ -259,6 +259,29 @@ dsError_t dsVideoPortSetPreferredColorDepth(intptr_t handle,dsDisplayColorDepth_
 dsError_t dsVideoPortGetPreferredColorDepth(intptr_t handle, dsDisplayColorDepth_t *colorDepth, bool persist );
 
 /**
+ * @brief Gets the EDID ALLM support
+ *
+ * For sink devices, this function gets the EDID ALLM support.
+ * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ *
+ * @param[in] iHdmiPort      - HDMI input port.  Please refer ::dsHdmiInPort_t
+ * @param[in] allmSupport    - Allm support. False for disabled, True for enabled
+ *
+ * @return dsError_t                        - Status
+ * @retval dsERR_NONE                       - Success
+ * @retval dsERR_NOT_INITIALIZED            - Module is not initialised
+ * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+ * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+ * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *
+ * @pre dsHdmiInInit() must be called before calling this API
+ *
+ * @warning  This API is Not thread safe
+ *
+ */
+dsError_t dsGetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool *allmSupport);
+
+/**
  * @brief Gets the encoding type of an audio port
  *
  * This function returns the current audio encoding setting for the specified audio port.


### PR DESCRIPTION


Reason for change: dsGetEdid2AllmSupport removal for hal header
Test Procedure: test purpose
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>

https://ccp.sys.comcast.net/browse/RDKEVD-445