### PR TITLE
RDKEMW-4577:Reduce dumpedidinfo logging and fix colorimetry api calls

### DIFF
--- a/rpc/cli/dsDisplay.c
+++ b/rpc/cli/dsDisplay.c
@@ -180,7 +180,7 @@ dsError_t dsGetEDIDBytes(intptr_t handle, unsigned char *edid, int *length)
         if (param.result == dsERR_NONE) {
             printf("dsCLI ::getEDIDBytes returns %d bytes\r\n", param.length);
             if (edid) {
-                memcpy_s(edid, *length, param.bytes, param.length);
+                rc = memcpy_s(edid, *length, param.bytes, param.length);
                 if(rc!=EOK)
                 {
                         ERR_CHK(rc);


### PR DESCRIPTION
Reason for change: Porting changes from rdkv to rdke
Test Procedure: Build and test