### PR TITLE
RDKEMW-4009: Add new AVI info frame APIs

### DIFF
--- a/ds/include/videoOutputPort.hpp
+++ b/ds/include/videoOutputPort.hpp
@@ -155,6 +155,9 @@ public:
         int getConnectedDeviceType() const {return _hdmiDeviceType;};
         bool isConnectedDeviceRepeater() const {return _isDeviceRepeater;};
         void getEDIDBytes(std::vector<uint8_t> &edid) const;
+	void setAllmEnabled(bool enable) const;
+	void setAVIContentType(dsAviContentType_t contentType) const;
+	void setAVIScanInformation(dsAVIScanInformation_t scanInfo) const;
 
 /**
  * @fn int hasSurround() const
@@ -269,7 +272,6 @@ public:
         void ResetOutputToSDR();
         bool SetHdmiPreference(dsHdcpProtocolVersion_t hdcpProtocol);
         int GetHdmiPreference();
-        void setAllmEnabled(bool enable);
 
 	bool setScartParameter(const std::string parameter, const std::string value);
 	int getVideoEOTF() const;

--- a/ds/videoOutputPort.cpp
+++ b/ds/videoOutputPort.cpp
@@ -912,16 +912,42 @@ int VideoOutputPort::GetHdmiPreference()
 
 /**
  * @fn void setAllmEnabled(bool enable); 
- * @brief Enables/Disables ALLM mode for HDMI output video port.
+ * @brief Enables/Disables ALLM mode for connected HDMI display.
  */
- void VideoOutputPort::setAllmEnabled(bool enable)
+ void VideoOutputPort::Display::setAllmEnabled(bool enable) const
  {
+     printf("VideoOutputPort::Display::setAllmEnabled \r\n");
      dsError_t ret = dsSetAllmEnabled(_handle,enable);
      if (ret != dsERR_NONE) {
          throw Exception(ret);
      }
  }
- 
+
+/**
+ * @fn void setAVIContentType(dsAviContentType_t contentType);
+ * @brief Sets HDMI AVI content type signalling.
+ */
+void VideoOutputPort::Display::setAVIContentType(dsAviContentType_t contentType) const
+{
+    printf("VideoOutputPort::Display::setAVIContentType \r\n");
+    dsError_t ret = dsSetAVIContentType(_handle,contentType);
+    if (ret != dsERR_NONE) {
+        throw Exception(ret);
+    }
+}
+
+/**
+ * @fn void setAVIScanInformation(dsAVIScanInformation_t scanInfo);
+ * @brief ets HDMI AVI scan info signalling.
+ */
+void VideoOutputPort::Display::setAVIScanInformation(dsAVIScanInformation_t scanInfo) const
+{
+    printf("VideoOutputPort::Display::setAVIScanInformation \r\n");
+    dsError_t ret = dsSetAVIScanInformation(_handle,scanInfo);
+    if (ret != dsERR_NONE) {
+        throw Exception(ret);
+    }
+}
 
 }
 

--- a/rpc/cli/dsDisplay.c
+++ b/rpc/cli/dsDisplay.c
@@ -201,6 +201,72 @@ dsError_t dsGetEDIDBytes(intptr_t handle, unsigned char *edid, int *length)
     }
 }
 
+dsError_t dsSetAllmEnabled (intptr_t  handle, bool enabled)
+{
+	_DEBUG_ENTER();
+
+	dsDisplaySetAllmEnabledParam_t param;
+	memset(&param, 0, sizeof(param));
+	param.handle = handle;
+	param.enabled = enabled;
+
+	IARM_Result_t rpcRet = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+			(char *) IARM_BUS_DSMGR_API_dsSetAllmEnabled,
+			(void *) &param,
+			sizeof(param));
+
+	if (IARM_RESULT_SUCCESS == rpcRet)
+	{
+		return param.result;
+	}
+
+	return dsERR_GENERAL ;
+}
+
+dsError_t dsSetAVIContentType (intptr_t  handle, dsAviContentType_t contentType)
+{
+        _DEBUG_ENTER();
+
+        dsDisplaySetAVIContentTypeParam_t param;
+        memset(&param, 0, sizeof(param));
+        param.handle = handle;
+        param.contentType = contentType;
+
+        IARM_Result_t rpcRet = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+                        (char *) IARM_BUS_DSMGR_API_dsSetAVIContentType,
+                        (void *) &param,
+                        sizeof(param));
+
+        if (IARM_RESULT_SUCCESS == rpcRet)
+        {
+                return param.result;
+        }
+
+        return dsERR_GENERAL ;
+}
+
+dsError_t dsSetAVIScanInformation (intptr_t  handle, dsAVIScanInformation_t scanInfo)
+{
+        _DEBUG_ENTER();
+
+        dsDisplaySetAVIScanInfoParam_t param;
+        memset(&param, 0, sizeof(param));
+        param.handle = handle;
+        param.scanInfo = scanInfo;
+
+        IARM_Result_t rpcRet = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+                        (char *) IARM_BUS_DSMGR_API_dsSetAVIScanInformation,
+                        (void *) &param,
+                        sizeof(param));
+
+        if (IARM_RESULT_SUCCESS == rpcRet)
+        {
+                return param.result;
+        }
+
+        return dsERR_GENERAL ;
+}
+
 dsError_t dsDisplayTerm(void)
 {
    _DEBUG_ENTER();

--- a/rpc/cli/dsVideoPort.c
+++ b/rpc/cli/dsVideoPort.c
@@ -965,27 +965,6 @@ dsError_t dsSetForceHDRMode(intptr_t handle, dsHDRStandard_t mode)
         return dsERR_GENERAL ;
 }
 
-dsError_t dsSetAllmEnabled (intptr_t  handle, bool enabled)
-{
-	_DEBUG_ENTER();
-
-	dsSetAllmEnabledParam_t param;
-	memset(&param, 0, sizeof(param));
-	param.handle = handle;
-	param.enabled = enabled;
-
-	IARM_Result_t rpcRet = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
-			(char *) IARM_BUS_DSMGR_API_dsSetAllmEnabled,
-			(void *) &param,
-			sizeof(param));
-
-	if (IARM_RESULT_SUCCESS == rpcRet)
-	{
-		return param.result;
-	}
-
-	return dsERR_GENERAL ;
-}
 
 /** @} */
 /** @} */

--- a/rpc/include/dsRpc.h
+++ b/rpc/include/dsRpc.h
@@ -132,6 +132,9 @@ extern "C" {
 #define IARM_BUS_DSMGR_API_dsGetDisplayAspectRatio		"dsGetDisplayAspectRatio"
 #define IARM_BUS_DSMGR_API_dsGetEDID					"dsGetEDID"
 #define IARM_BUS_DSMGR_API_dsGetEDIDBytes               "dsGetEDIDBytes"
+#define IARM_BUS_DSMGR_API_dsSetAllmEnabled "dsSetAllmEnabled"
+#define IARM_BUS_DSMGR_API_dsSetAVIContentType "dsSetAVIContentType"
+#define IARM_BUS_DSMGR_API_dsSetAVIScanInformation "dsSetAVIScanInformation"
 #define IARM_BUS_DSMGR_API_dsDisplayTerm				"dsDisplayTerm"
 
 
@@ -612,6 +615,27 @@ typedef struct _dsDisplayGetEDIDParam_t {
     dsDisplayEDID_t edid;
 } dsDisplayGetEDIDParam_t;
 
+typedef struct _dsDisplaySetAVIContentTypeParam_t
+{
+    dsError_t result;
+    intptr_t  handle;
+    dsAviContentType_t contentType;
+}dsDisplaySetAVIContentTypeParam_t;
+
+typedef struct _dsDisplaySetAVIScanInfoParam_t
+{
+    dsError_t result;
+    intptr_t  handle;
+    dsAVIScanInformation_t scanInfo;
+}dsDisplaySetAVIScanInfoParam_t;
+
+typedef struct _dsDisplaySetAllmEnabledParam_t
+{
+    dsError_t result;
+    intptr_t  handle;
+    bool     enabled;
+}dsDisplaySetAllmEnabledParam_t;
+
 typedef struct _dsSupportedResolutionParam_t {
     dsError_t result;
     intptr_t  handle;
@@ -996,14 +1020,6 @@ typedef struct _dsEdidVersionParam_t
     dsHdmiInPort_t          iHdmiPort;
     tv_hdmi_edid_version_t  iEdidVersion;
 }dsEdidVersionParam_t;
-
-typedef struct _dsSetAllmEnabledParam_t
-{
-    dsError_t result;
-    intptr_t  handle;
-    bool     enabled;
-}dsSetAllmEnabledParam_t;
-
 
 typedef struct _dsEdidAllmSupportParam_t
 {

--- a/rpc/srv/dsDisplay.c
+++ b/rpc/srv/dsDisplay.c
@@ -68,6 +68,9 @@ IARM_Result_t _dsGetDisplay(void *arg);
 IARM_Result_t _dsGetDisplayAspectRatio(void *arg);
 IARM_Result_t _dsGetEDID(void *arg);
 IARM_Result_t _dsGetEDIDBytes(void *arg);
+IARM_Result_t _dsSetAllmEnabled(void *arg);
+IARM_Result_t _dsSetAVIContentType(void *arg);
+IARM_Result_t _dsSetAVIScanInformation(void *arg);
 IARM_Result_t _dsDisplayTerm(void *arg);
 void _dsDisplayEventCallback(intptr_t handle, dsDisplayEvent_t event, void *eventData);
 static void  filterEDIDResolution(intptr_t Shandle, dsDisplayEDID_t *edid);
@@ -120,6 +123,9 @@ IARM_Result_t _dsDisplayInit(void *arg)
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsGetDisplayAspectRatio,_dsGetDisplayAspectRatio);
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsGetEDID,_dsGetEDID);
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsGetEDIDBytes,_dsGetEDIDBytes);
+		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsSetAllmEnabled,_dsSetAllmEnabled);
+                IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsSetAVIContentType,_dsSetAVIContentType);
+                IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsSetAVIScanInformation,_dsSetAVIScanInformation);
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsDisplayTerm,_dsDisplayTerm);
 
 		m_isInitialized = 1;
@@ -270,6 +276,207 @@ IARM_Result_t _dsGetEDIDBytes(void *arg)
     IARM_BUS_Unlock(lock);
 	
 	return IARM_RESULT_SUCCESS;
+}
+
+IARM_Result_t _dsSetAllmEnabled(void* arg)
+{
+#ifndef RDK_DSHAL_NAME
+#warning   "RDK_DSHAL_NAME is not defined"
+#define RDK_DSHAL_NAME "RDK_DSHAL_NAME is not defined"
+#endif
+    _DEBUG_ENTER();
+    IARM_BUS_Lock(lock);
+    dsError_t ret = dsERR_NONE;
+
+    typedef dsError_t (*dsSetAllmEnabled_t)(intptr_t handle, bool enabled);
+    typedef dsError_t (*dsGetAllmEnabled_t)(intptr_t handle, bool *enabled);
+    static dsSetAllmEnabled_t func_dsSetAllmEnabled = 0;
+    static dsGetAllmEnabled_t func_dsGetAllmEnabled = 0;
+    if (func_dsGetAllmEnabled == 0 &&  func_dsSetAllmEnabled  == 0) {
+        void *dllib = dlopen(RDK_DSHAL_NAME, RTLD_LAZY);
+        if (dllib) {
+            func_dsGetAllmEnabled = (dsGetAllmEnabled_t) dlsym(dllib, "dsGetAllmEnabled");
+            func_dsSetAllmEnabled = (dsSetAllmEnabled_t) dlsym(dllib, "dsSetAllmEnabled");
+            if (func_dsGetAllmEnabled && func_dsSetAllmEnabled) {
+                INT_DEBUG(" dsGetAllmEnabled (intptr_t  handle, bool *enabled) and dsSetAllmEnabled (intptr_t  handle, bool enabled) is defined and loaded\r\n");
+            }
+            else {
+                INT_INFO(" dsGetAllmEnabled (intptr_t  handle, bool *enabled) and dsSetAllmEnabled (intptr_t  handle, bool enabled) is not defined\r\n");
+            }
+            dlclose(dllib);
+        }
+        else {
+            INT_ERROR("Opening RDK_DSHAL_NAME [%s] failed\r\n", RDK_DSHAL_NAME);
+        }
+    }
+
+    dsDisplaySetAllmEnabledParam_t *param = (dsDisplaySetAllmEnabledParam_t *)arg;
+
+    if (func_dsGetAllmEnabled != 0 &&  func_dsSetAllmEnabled  != 0)
+    {
+	    bool currentALLMState = false;
+	    ret = func_dsGetAllmEnabled (param->handle, &currentALLMState);
+	    if (ret == dsERR_NONE)
+	    {
+		    if (currentALLMState == param->enabled)
+		    {
+			    INT_INFO("ALLM mode already %s for HDMI output video port \r\n",currentALLMState ? "Enabled" :"Disabled");
+		    }
+		    else{
+			    INT_INFO("Current ALLM state  %s Requested to %s\r\n", (currentALLMState ? "Enabled" :"Disabled") ,(param->enabled ? "Enabled" :"Disabled"));
+			    ret = func_dsSetAllmEnabled(param->handle, param->enabled);
+			    param->result = ret;
+			    INT_INFO("dsSetAllmEnabled ret: %d \r\n",ret);
+		    }
+	    }
+	    else
+	    {
+		    INT_INFO("dsGetAllmEnabled failed ret: %d \r\n",ret);
+		    param->result = dsERR_GENERAL;
+	    }
+
+    }
+    else {
+        param->result = dsERR_GENERAL;
+    }
+
+    IARM_BUS_Unlock(lock);
+
+    return IARM_RESULT_SUCCESS;
+}
+
+IARM_Result_t _dsSetAVIContentType(void* arg)
+{
+#ifndef RDK_DSHAL_NAME
+#warning   "RDK_DSHAL_NAME is not defined"
+#define RDK_DSHAL_NAME "RDK_DSHAL_NAME is not defined"
+#endif
+    _DEBUG_ENTER();
+    IARM_BUS_Lock(lock);
+    dsError_t ret = dsERR_NONE;
+
+    typedef dsError_t (*dsSetAVIContentType_t)(intptr_t handle, dsAviContentType_t contentType);
+    typedef dsError_t (*dsGetAVIContentType_t)(intptr_t handle, dsAviContentType_t* contentType);
+    static dsSetAVIContentType_t func_dsSetAVIContentType = 0;
+    static dsGetAVIContentType_t func_dsGetAVIContentType = 0;
+    if (func_dsGetAVIContentType == 0 &&  func_dsSetAVIContentType  == 0) {
+        void *dllib = dlopen(RDK_DSHAL_NAME, RTLD_LAZY);
+        if (dllib) {
+            func_dsSetAVIContentType = (dsSetAVIContentType_t) dlsym(dllib, "dsSetAVIContentType");
+			func_dsGetAVIContentType = (dsGetAVIContentType_t) dlsym(dllib, "dsGetAVIContentType");
+            if (func_dsGetAVIContentType && func_dsSetAVIContentType) {
+                INT_DEBUG(" dsGetAVIContentType (intptr_t, dsAviContentType_t*) and dsSetAVIContentType (intptr_t, dsAviContentType_t) is defined and loaded\r\n");
+            }
+            else {
+                INT_INFO(" dsGetAVIContentType (intptr_t , dsAviContentType_t*) and dsSetAVIContentType (intptr_t, dsAviContentType_t) is not defined\r\n");
+            }
+            dlclose(dllib);
+        }
+        else {
+            INT_ERROR("Opening RDK_DSHAL_NAME [%s] failed\r\n", RDK_DSHAL_NAME);
+        }
+    }
+
+    dsDisplaySetAVIContentTypeParam_t *param = (dsDisplaySetAVIContentTypeParam_t *)arg;
+
+    if (func_dsGetAVIContentType != 0 &&  func_dsSetAVIContentType  != 0)
+    {
+	    dsAviContentType_t contentType = dsAVICONTENT_TYPE_NOT_SIGNALLED;
+	    ret = func_dsGetAVIContentType (param->handle, &contentType);
+	    if (ret == dsERR_NONE)
+	    {
+		    if (contentType == param->contentType)
+		    {
+			    INT_INFO("HDMI AVI content type already set to %d\r\n",contentType);
+		    }
+		    else{
+			    INT_INFO("Current AVI content type %d, requested content type %d\r\n",contentType,param->contentType);
+			    ret = func_dsSetAVIContentType(param->handle, param->contentType);
+			    param->result = ret;
+			    INT_INFO("dsSetAVIContentType ret: %d \r\n",ret);
+		    }
+	    }
+	    else
+	    {
+		    INT_INFO("dsGetAVIContentType failed ret: %d \r\n",ret);
+		    param->result = dsERR_GENERAL;
+	    }
+
+    }
+    else {
+        param->result = dsERR_GENERAL;
+    }
+
+    IARM_BUS_Unlock(lock);
+
+    return IARM_RESULT_SUCCESS;
+}
+
+IARM_Result_t _dsSetAVIScanInformation(void* arg)
+{
+#ifndef RDK_DSHAL_NAME
+#warning   "RDK_DSHAL_NAME is not defined"
+#define RDK_DSHAL_NAME "RDK_DSHAL_NAME is not defined"
+#endif
+    _DEBUG_ENTER();
+    IARM_BUS_Lock(lock);
+    dsError_t ret = dsERR_NONE;
+
+    typedef dsError_t (*dsSetAVIScanInfo_t)(intptr_t handle, dsAVIScanInformation_t scanInfo);
+    typedef dsError_t (*dsGetAVIScanInfo_t)(intptr_t handle, dsAVIScanInformation_t* scanInfo);
+    static dsSetAVIScanInfo_t func_dsSetAVIScanInfo = 0;
+    static dsGetAVIScanInfo_t func_dsGetAVIScanInfo = 0;
+    if (func_dsGetAVIScanInfo == 0 &&  func_dsSetAVIScanInfo  == 0) {
+        void *dllib = dlopen(RDK_DSHAL_NAME, RTLD_LAZY);
+        if (dllib) {
+            func_dsSetAVIScanInfo = (dsSetAVIScanInfo_t) dlsym(dllib, "dsSetAVIScanInformation");
+			func_dsGetAVIScanInfo = (dsGetAVIScanInfo_t) dlsym(dllib, "dsGetAVIScanInformation");
+            if (func_dsGetAVIScanInfo && func_dsSetAVIScanInfo) {
+                INT_DEBUG(" dsGetAVIScanInformation(intptr_t, dsAVIScanInformation_t*) and dsSetAVIScanInformation(intptr_t, dsAVIScanInformation_t) is defined and loaded\r\n");
+            }
+            else {
+                INT_INFO(" dsGetAVIScanInformation(intptr_t , dsAVIScanInformation_t*) and dsSetAVIScanInformation(intptr_t, dsAVIScanInformation_t) is not defined\r\n");
+            }
+            dlclose(dllib);
+        }
+        else {
+            INT_ERROR("Opening RDK_DSHAL_NAME [%s] failed\r\n", RDK_DSHAL_NAME);
+        }
+    }
+
+    dsDisplaySetAVIScanInfoParam_t *param = (dsDisplaySetAVIScanInfoParam_t *)arg;
+
+    if (func_dsGetAVIScanInfo != 0 &&  func_dsSetAVIScanInfo  != 0)
+    {
+	    dsAVIScanInformation_t scanInfo = dsAVI_SCAN_TYPE_NO_DATA;
+	    ret = func_dsGetAVIScanInfo (param->handle, &scanInfo);
+	    if (ret == dsERR_NONE)
+	    {
+		    if (scanInfo == param->scanInfo)
+		    {
+			    INT_INFO("HDMI AVI scan Info already set to %d\r\n",scanInfo);
+		    }
+		    else{
+			    INT_INFO("Current AVI scan Info %d, requested scan Info %d\r\n",scanInfo,param->scanInfo);
+			    ret = func_dsSetAVIScanInfo(param->handle, param->scanInfo);
+			    param->result = ret;
+			    INT_INFO("dsSetAVIScanInformation ret: %d \r\n",ret);
+		    }
+	    }
+	    else
+	    {
+		    INT_INFO("dsGetAVIScanInformation failed ret: %d \r\n",ret);
+		    param->result = dsERR_GENERAL;
+	    }
+
+    }
+    else {
+        param->result = dsERR_GENERAL;
+    }
+
+    IARM_BUS_Unlock(lock);
+
+    return IARM_RESULT_SUCCESS;
 }
 
 IARM_Result_t _dsDisplayTerm(void *arg)

--- a/rpc/srv/dsVideoPort.c
+++ b/rpc/srv/dsVideoPort.c
@@ -116,7 +116,6 @@ IARM_Result_t _dsGetCurrentOutputSettings(void* arg);
 IARM_Result_t _dsSetBackgroundColor(void *arg);
 IARM_Result_t _dsSetForceHDRMode(void *arg);
 IARM_Result_t _dsGetIgnoreEDIDStatus(void *arg);
-IARM_Result_t _dsSetAllmEnabled(void *arg);
 
 
 void _dsVideoFormatUpdateCB(dsHDRStandard_t videoFormat);
@@ -317,7 +316,6 @@ IARM_Result_t _dsVideoPortInit(void *arg)
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsColorDepthCapabilities,_dsColorDepthCapabilities);
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsGetPreferredColorDepth,_dsGetPreferredColorDepth);
 		IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsSetPreferredColorDepth,_dsSetPreferredColorDepth);
-        IARM_Bus_RegisterCall(IARM_BUS_DSMGR_API_dsSetAllmEnabled,_dsSetAllmEnabled);
 	
         dsError_t eRet = _dsVideoFormatUpdateRegisterCB (_dsVideoFormatUpdateCB) ;
         if (dsERR_NONE != eRet) {
@@ -2403,73 +2401,5 @@ intptr_t dsGetDefaultPortHandle()
     }
     return halhandle;
 }
-
-IARM_Result_t _dsSetAllmEnabled(void* arg)
-{
-#ifndef RDK_DSHAL_NAME
-#warning   "RDK_DSHAL_NAME is not defined"
-#define RDK_DSHAL_NAME "RDK_DSHAL_NAME is not defined"
-#endif
-    _DEBUG_ENTER();
-    IARM_BUS_Lock(lock);
-    dsError_t ret = dsERR_NONE;
-
-    typedef dsError_t (*dsSetAllmEnabled_t)(intptr_t handle, bool enabled);
-    typedef dsError_t (*dsGetAllmEnabled_t)(intptr_t handle, bool *enabled);
-    static dsSetAllmEnabled_t func_dsSetAllmEnabled = 0;
-    static dsGetAllmEnabled_t func_dsGetAllmEnabled = 0;
-    if (func_dsGetAllmEnabled == 0 &&  func_dsSetAllmEnabled  == 0) {
-        void *dllib = dlopen(RDK_DSHAL_NAME, RTLD_LAZY);
-        if (dllib) {
-            func_dsGetAllmEnabled = (dsGetAllmEnabled_t) dlsym(dllib, "dsGetAllmEnabled");
-            func_dsSetAllmEnabled = (dsSetAllmEnabled_t) dlsym(dllib, "dsSetAllmEnabled");
-            if (func_dsGetAllmEnabled && func_dsSetAllmEnabled) {
-                INT_DEBUG(" dsGetAllmEnabled (intptr_t  handle, bool *enabled) and dsSetAllmEnabled (intptr_t  handle, bool enabled) is defined and loaded\r\n");
-            }
-            else {
-                INT_INFO(" dsGetAllmEnabled (intptr_t  handle, bool *enabled) and dsSetAllmEnabled (intptr_t  handle, bool enabled) is not defined\r\n");
-            }
-            dlclose(dllib);
-        }
-        else {
-            INT_ERROR("Opening RDK_DSHAL_NAME [%s] failed\r\n", RDK_DSHAL_NAME);
-        }
-    }
-
-    dsSetAllmEnabledParam_t *param = (dsSetAllmEnabledParam_t *)arg;
-
-    if (func_dsGetAllmEnabled != 0 &&  func_dsSetAllmEnabled  != 0)
-    {
-	    bool currentALLMState = false;
-	    ret = func_dsGetAllmEnabled (param->handle, &currentALLMState);
-	    if (ret == dsERR_NONE)
-	    {
-		    if (currentALLMState == param->enabled)
-		    {
-			    INT_INFO("ALLM mode already %s for HDMI output video port \r\n",currentALLMState ? "Enabled" :"Disabled");
-		    }
-		    else{    
-			    INT_INFO("Current ALLM state  %s Requested to %s\r\n", (currentALLMState ? "Enabled" :"Disabled") ,(param->enabled ? "Enabled" :"Disabled"));
-			    ret = func_dsSetAllmEnabled(param->handle, param->enabled);
-			    param->result = ret;
-			    INT_INFO("dsSetAllmEnabled ret: %d \r\n",ret);
-		    }
-	    }
-	    else
-	    {
-		    INT_INFO("dsGetAllmEnabled failed ret: %d \r\n",ret);
-		    param->result = dsERR_GENERAL;
-	    }
-
-    }
-    else {
-        param->result = dsERR_GENERAL;
-    }
-
-    IARM_BUS_Unlock(lock);
-
-    return IARM_RESULT_SUCCESS;
-}
-
 /** @} */
 /** @} */


### PR DESCRIPTION
Reason for change:
1.Moving ALLM APIs from dsVideoPort to dsDisplay
2.Add new AVI content type and scan info APIs

Test Procedure: build and verify using curl commands
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk