### PR TITLE
RDKEMW-6595: Fix coverity issue in devicesettings (#87)

### DIFF
--- a/ds/videoOutputPort.cpp
+++ b/ds/videoOutputPort.cpp
@@ -480,8 +480,9 @@ void VideoOutputPort::setResolution(const std::string &resolutionName, bool pers
 	resolution.pixelResolution 	= (dsVideoResolution_t)	newResolution.getPixelResolution().getId();
 	resolution.stereoScopicMode = (dsVideoStereoScopicMode_t)newResolution.getStereoscopicMode().getId();
         strncpy(resolution.name,resolutionName.c_str(),sizeof(resolution.name));
-
-       dsError_t ret = dsVideoPortSetResolution(_handle, &resolution, persist);
+        resolution.name[sizeof(resolution.name) - 1] = '\0';  // Ensure null-termination
+	
+        dsError_t ret = dsVideoPortSetResolution(_handle, &resolution, persist);
 
 	if (ret != dsERR_NONE) {
 		throw Exception(ret);

--- a/rpc/cli/dsAudio.c
+++ b/rpc/cli/dsAudio.c
@@ -411,18 +411,19 @@ dsError_t dsSetStereoMode(intptr_t handle, dsAudioStereoMode_t mode,bool isPersi
     _RETURN_IF_ERROR(dsAudioStereoMode_isValid(mode), dsERR_INVALID_PARAM);
 
     dsAudioSetStereoModeParam_t param;
+    IARM_Result_t rpcRet = IARM_RESULT_SUCCESS;
 
     param.handle = handle;
     param.mode = mode;
     param.rpcResult = dsERR_NONE;
     param.toPersist = isPersist;
 
-    IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+    rpcRet = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
                  (char *)IARM_BUS_DSMGR_API_dsSetStereoMode,
                  (void *)&param,
                  sizeof(param));
 
-    if (dsERR_NONE == param.rpcResult)
+    if ((rpcRet == IARM_RESULT_SUCCESS) && (dsERR_NONE == param.rpcResult))
     {
         return dsERR_NONE;
     }

--- a/rpc/srv/dsAudio.c
+++ b/rpc/srv/dsAudio.c
@@ -669,7 +669,9 @@ void AudioConfigInit()
                 if (dsSetMS12AudioProfileFunc) {
                     INT_DEBUG("dsSetMS12AudioProfile_t(int, const char*) is defined and loaded\r\n");
                     handle = 0;
-                    dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle);
+                    if(dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle) != dsERR_NONE) {
+                        INT_ERROR("dsGetAudioPort failed for SPEAKER0\n");
+                    }
 
                     try {
                         _AProfile = device::HostPersistence::getInstance().getProperty("audio.MS12Profile");
@@ -1268,10 +1270,11 @@ void AudioConfigInit()
                             }
                 //SPEAKER init
                             handle = 0;
-                            dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle);
-                            if (dsSetMISteeringFunc(handle, m_MISteering) == dsERR_NONE) {
-                                INT_INFO("Port %s: Initialized MI Steering : %d\n","SPEAKER0", m_MISteering);
-                            }
+                            if (dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle) == dsERR_NONE) {
+                                if (dsSetMISteeringFunc(handle, m_MISteering) == dsERR_NONE) {
+                                    INT_INFO("Port %s: Initialized MI Steering : %d\n","SPEAKER0", m_MISteering);
+                                }
+			    }
                 //HDMI init
                             handle = 0;
                             if (dsGetAudioPort(dsAUDIOPORT_TYPE_HDMI,0,&handle) == dsERR_NONE) {
@@ -1320,8 +1323,11 @@ void AudioConfigInit()
                         std::string _GEQMode("0");
                         int m_GEQMode = 0;
                         handle = 0;
-                        dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle);
-                        try {
+                        if(dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle) != dsERR_NONE) {
+                            INT_ERROR("dsGetAudioPort failed for SPEAKER0\n");
+                        }
+
+		        try {
                             _GEQMode = device::HostPersistence::getInstance().getProperty("audio.GraphicEQ");
                             m_GEQMode = atoi(_GEQMode.c_str());
                 //SPEAKER init
@@ -1521,7 +1527,9 @@ void AudioConfigInit()
                        std::string _IEQMode("0");
                        int m_IEQMode = 0;
                        handle = 0;
-                       dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle);
+                       if (dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle) != dsERR_NONE) {
+		           INT_ERROR("dsGetAudioPort failed for SPEAKER0\n");
+		       }
                        try {
                            _IEQMode = device::HostPersistence::getInstance().getProperty("audio.IntelligentEQ");
                        }
@@ -1901,7 +1909,9 @@ void AudioConfigInit()
                        std::string _GEQMode("0");
                        int m_GEQMode = 0;
                        handle = 0;
-                       dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle);
+                       if (dsGetAudioPort(dsAUDIOPORT_TYPE_SPEAKER,0,&handle) != dsERR_NONE) {
+			       INT_ERROR("dsGetAudioPort failed for SPEAKER0\n");
+		       }
                        try {
                            _GEQMode = device::HostPersistence::getInstance().getProperty("audio.GraphicEQ");
                        }
@@ -2656,7 +2666,9 @@ IARM_Result_t _dsSetStereoMode(void *arg)
 IARM_Result_t _dsGetStereoAuto(void *arg)
 {
     _DEBUG_ENTER();
-
+    if ( !arg ) {
+        return IARM_RESULT_INVALID_PARAM;
+    }
     IARM_BUS_Lock(lock);
 
     dsAudioSetStereoAutoParam_t *param = (dsAudioSetStereoAutoParam_t *)arg;
@@ -7040,41 +7052,50 @@ IARM_Result_t _dsGetHDMIARCPortId(void *arg)
 static void* persist_audioLevel_timer_threadFunc(void* arg) {
 	float prev_audioLevel_spdif = 0.0, prev_audioLevel_speaker = 0.0, prev_audioLevel_hdmi = 0.0, prev_audioLevel_headphone = 0.0;
 	INT_DEBUG("%s Audio level persistence update timer thread running...\n",__func__);
+	struct timespec ts;
 	    while(1){
-              // wait for 3 sec, then update the latest audio level from cache variable
+	      clock_gettime(CLOCK_REALTIME, &ts);
+              ts.tv_sec += 5;
 
               pthread_mutex_lock(&audioLevelMutex);
-              pthread_cond_wait(&audioLevelTimerCV, &audioLevelMutex);
+              while(!audioLevel_timer_set){
+                int rc = pthread_cond_timedwait(&audioLevelTimerCV, &audioLevelMutex, &ts);
+                if (rc == ETIMEDOUT)
+                        continue;
+              }
               if(!persist_audioLevel_timer_threadIsAlive){
+		pthread_mutex_unlock(&audioLevelMutex);
                 break;
               }
-              sleep(3);
+	      // wait for 3 sec, then update the latest audio level from cache variable
+	      if(audioLevel_timer_set){
+                sleep(3);
 
-              if(float(audioLevel_cache_spdif) != prev_audioLevel_spdif){
-                INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"SPDIF0.audio.Level",float(audioLevel_cache_spdif));
-                device::HostPersistence::getInstance().persistHostProperty("SPDIF0.audio.Level",std::to_string(audioLevel_cache_spdif));
-                prev_audioLevel_spdif = float(audioLevel_cache_spdif);
-              }
-              if(float(audioLevel_cache_hdmi) != prev_audioLevel_hdmi){
-                INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"HDMI0.audio.Level",float(audioLevel_cache_hdmi));
-                device::HostPersistence::getInstance().persistHostProperty("HDMI0.audio.Level",std::to_string(audioLevel_cache_hdmi));
-                prev_audioLevel_hdmi = float(audioLevel_cache_hdmi);
-              }
-              if(float(audioLevel_cache_speaker) != prev_audioLevel_speaker){
-                INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"SPEAKER0.audio.Level",float(audioLevel_cache_speaker));
-                device::HostPersistence::getInstance().persistHostProperty("SPEAKER0.audio.Level",std::to_string(audioLevel_cache_speaker));
-                prev_audioLevel_speaker = float(audioLevel_cache_speaker);
-              }
-              if(float(audioLevel_cache_headphone) != prev_audioLevel_headphone){
-                INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"HEADPHONE0.audio.Level",float(audioLevel_cache_headphone));
-                device::HostPersistence::getInstance().persistHostProperty("HEADPHONE0.audio.Level",std::to_string(audioLevel_cache_headphone));
-                prev_audioLevel_headphone = float(audioLevel_cache_headphone);
-              }
-              else{
-                INT_INFO("%s Audio level is same as last set value.Not updating persistence\n",__func__);
-              }
-
-              audioLevel_timer_set = false;
+                if(float(audioLevel_cache_spdif) != prev_audioLevel_spdif){
+                  INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"SPDIF0.audio.Level",float(audioLevel_cache_spdif));
+                  device::HostPersistence::getInstance().persistHostProperty("SPDIF0.audio.Level",std::to_string(audioLevel_cache_spdif));
+                  prev_audioLevel_spdif = float(audioLevel_cache_spdif);
+                }
+                if(float(audioLevel_cache_hdmi) != prev_audioLevel_hdmi){
+                  INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"HDMI0.audio.Level",float(audioLevel_cache_hdmi));
+                  device::HostPersistence::getInstance().persistHostProperty("HDMI0.audio.Level",std::to_string(audioLevel_cache_hdmi));
+                  prev_audioLevel_hdmi = float(audioLevel_cache_hdmi);
+                }
+                if(float(audioLevel_cache_speaker) != prev_audioLevel_speaker){
+                  INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"SPEAKER0.audio.Level",float(audioLevel_cache_speaker));
+                  device::HostPersistence::getInstance().persistHostProperty("SPEAKER0.audio.Level",std::to_string(audioLevel_cache_speaker));
+                  prev_audioLevel_speaker = float(audioLevel_cache_speaker);
+                }
+                if(float(audioLevel_cache_headphone) != prev_audioLevel_headphone){
+                  INT_INFO("%s: port: %s ,persist audio level: %f\n",__func__,"HEADPHONE0.audio.Level",float(audioLevel_cache_headphone));
+                  device::HostPersistence::getInstance().persistHostProperty("HEADPHONE0.audio.Level",std::to_string(audioLevel_cache_headphone));
+                  prev_audioLevel_headphone = float(audioLevel_cache_headphone);
+                }
+                else{
+                  INT_INFO("%s Audio level is same as last set value.Not updating persistence\n",__func__);
+                }
+                audioLevel_timer_set = false;
+	      }
               pthread_mutex_unlock(&audioLevelMutex);
             }
 

--- a/rpc/srv/dsCompositeIn.c
+++ b/rpc/srv/dsCompositeIn.c
@@ -123,11 +123,9 @@ IARM_Result_t dsCompositeInMgr_term()
 
 IARM_Result_t _dsCompositeInInit(void *arg)
 {
+    IARM_BUS_Lock(lock);
     INT_INFO("%s:%d ---> m_isInitialized=%d, m_isPlatInitialized=%d \n",
                    __PRETTY_FUNCTION__,__LINE__, m_isInitialized, m_isPlatInitialized);
-
-    IARM_BUS_Lock(lock);
-
 
     if (PROFILE_TV == profileType)
     {
@@ -266,9 +264,9 @@ IARM_Result_t _dsCompositeInInit(void *arg)
 IARM_Result_t _dsCompositeInTerm(void *arg)
 {
     _DEBUG_ENTER();
+    IARM_BUS_Lock(lock);
     INT_DEBUG("%s:%d ---> m_isPlatInitialized=%d\n", __PRETTY_FUNCTION__,__LINE__, m_isPlatInitialized);
 
-    IARM_BUS_Lock(lock);
     if (PROFILE_TV == profileType)
     {
         INT_INFO("[%d][%s]: its TV Profile\r\n", __LINE__, __FUNCTION__);

--- a/rpc/srv/dsDisplay.c
+++ b/rpc/srv/dsDisplay.c
@@ -114,6 +114,7 @@ IARM_Result_t _dsDisplayInit(void *arg)
             eReturn = dsGetDisplay(dsVIDEOPORT_TYPE_INTERNAL, 0, &handle);
             if (dsERR_NONE != eReturn) {
                 INT_ERROR("dsGetDisplay for dsVIDEOPORT_TYPE_INTERNAL also failed.\r\n");
+                IARM_BUS_Unlock(lock);
                 return IARM_RESULT_INVALID_PARAM;
             }
         }
@@ -173,6 +174,9 @@ IARM_Result_t _dsGetDisplayAspectRatio(void *arg)
 IARM_Result_t _dsGetEDID(void *arg)
 {
     _DEBUG_ENTER();
+    if (!arg) {   //  coverity - FORWARD_NULL check
+       return IARM_RESULT_INVALID_PARAM;
+    }
     errno_t rc = -1;
     static dsDisplayEDID_t *edidInfo = (dsDisplayEDID_t*)malloc(sizeof(dsDisplayEDID_t));
     dsDisplayGetEDIDParam_t *param = (dsDisplayGetEDIDParam_t *)arg;
@@ -214,6 +218,10 @@ IARM_Result_t _dsGetEDIDBytes(void *arg)
 #endif
     errno_t rc = -1;
     _DEBUG_ENTER();
+    if (!arg) {   //  coverity - FORWARD_NULL check
+       return IARM_RESULT_INVALID_PARAM;
+    }
+
     static unsigned char edid[1024] = {0};
     static int length = 0;
    dsDisplayGetEDIDBytesParam_t *param = (dsDisplayGetEDIDBytesParam_t *)arg;

--- a/rpc/srv/dsHdmiIn.c
+++ b/rpc/srv/dsHdmiIn.c
@@ -482,11 +482,10 @@ IARM_Result_t dsHdmiInMgr_term()
 
 IARM_Result_t _dsHdmiInInit(void *arg)
 {
+    IARM_BUS_Lock(lock);
     INT_INFO("%s:%d ---> m_isInitialized=%d, m_isPlatInitialized=%d \n",
                    __PRETTY_FUNCTION__,__LINE__, m_isInitialized, m_isPlatInitialized);
 
-
-    IARM_BUS_Lock(lock);
     getDynamicAutoLatencyConfig();
 
     if (PROFILE_TV == profileType)
@@ -1404,9 +1403,9 @@ IARM_Result_t _dsSetVRRSupport (void *arg)
     _DEBUG_ENTER();
 
     dsVRRSupportParam_t *param = (dsVRRSupportParam_t *) arg;
+    IARM_BUS_Lock(lock);
     param->result = dsERR_NONE;
     INT_INFO("[srv] :  In _dsSetVRRSupport, checking m_ediversion of port %d : %d\n",param->iHdmiPort,m_edidversion[param->iHdmiPort]);
-    IARM_BUS_Lock(lock);
     if(m_edidversion[param->iHdmiPort] == HDMI_EDID_VER_20)//if the edidver is 2.0, then only set the VRR bit in edid
     {
         param->result = setVRRSupport (param->iHdmiPort, param->vrrSupport);

--- a/rpc/srv/dsVideoPort.c
+++ b/rpc/srv/dsVideoPort.c
@@ -277,7 +277,8 @@ IARM_Result_t _dsVideoPortInit(void *arg)
                    if (dsERR_NONE != eReturn) {
                         eReturn = dsGetVideoPort(dsVIDEOPORT_TYPE_INTERNAL,0,&handle);
                    }
-                   INT_INFO("calling dsRegisterHdcpStatusCallback with handle:%p \n",handle);
+                   /* coverity[print_args] */
+		   INT_INFO("calling dsRegisterHdcpStatusCallback with handle:%p \n",(void *)handle);
 		   dsRegisterHdcpStatusCallback(handle,_dsHdcpCallback);
 		#endif
 		
@@ -923,7 +924,7 @@ IARM_Result_t _dsSetResolution(void *arg)
 		//IsIgnoreEdid is true platform will take care of current resolution cache.
 		if (!IsIgnoreEdid) {
 			dsVideoPortResolution_t platresolution;
-			memset(platresolution.name,'\0',sizeof(platresolution.name));
+			memset(&platresolution,'\0',sizeof(platresolution));
 			dsGetResolution(param->handle,&platresolution);
 			INT_INFO("Resolution Requested ..%s Platform Resolution - %s\r\n",resolution.name,platresolution.name);
 			if ((strcmp(resolution.name,platresolution.name) == 0 ))
@@ -1771,7 +1772,7 @@ static void persistResolution(dsVideoPortSetResolutionParam_t *param)
 			}
 
 			INT_DEBUG("Set Resolution on Component/Composite Ports!!!!!!..\r\n");
-			_dsCompResolution = resolutionName;
+			_dsCompResolution = std::move(resolutionName);
 			if (false == IsCompatibleResolution(resolution.pixelResolution,getPixelResolution(_dsHDMIResolution)))
 			{
 				INT_INFO("HDMI Resolution is not Compatible with Analog ports..\r\n");
@@ -1799,7 +1800,7 @@ static void persistResolution(dsVideoPortSetResolutionParam_t *param)
                         }
 
                         INT_DEBUG("Set Resolution on Composite Ports!!!!!!..\r\n");
-                        _dsBBResolution = resolutionName;
+                        _dsBBResolution = std::move(resolutionName);
                         if (false == IsCompatibleResolution(resolution.pixelResolution,getPixelResolution(_dsHDMIResolution)))
                         {
                                 INT_INFO("HDMI Resolution is not Compatible with Analog ports..\r\n");
@@ -1823,7 +1824,7 @@ static void persistResolution(dsVideoPortSetResolutionParam_t *param)
                         }
 
                         INT_DEBUG("Set Resolution on RF Ports!!!!!!..\r\n");
-                        _dsRFResolution = resolutionName;
+                        _dsRFResolution = std::move(resolutionName);
                         if (false == IsCompatibleResolution(resolution.pixelResolution,getPixelResolution(_dsHDMIResolution)))
                         {
                                 INT_INFO("HDMI Resolution is not Compatible with Analog ports..\r\n");
@@ -2356,7 +2357,7 @@ void _dsSyncHdmiStatus(const std::string& key, int val) {
 	} else if (0 == strncmp (key.c_str(), DS_HDMI_TAG_HDCPVERSION, strlen(DS_HDMI_TAG_HDCPVERSION))){
 		value = getHdcpVersionName (val);
 	} else {
-		INT_INFO("dsSRV: %s: unknown key is passed %s\r\n", __FUNCTION__, key);
+		INT_INFO("dsSRV: %s: unknown key is passed %s\r\n", __FUNCTION__, key.c_str());
 	}
     // Read existing lines and remove the target line if it exists
     while (std::getline(statusFile, line)) {

--- a/sample/powerModeTest.cpp
+++ b/sample/powerModeTest.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 			printf("SetPreferredSleepMode - 's'\n");
 			printf("All Sleep Modes - 'l' \n");
 			printf("Exit - 'x'\n");
-			c = getchar();
+			std::cin >> c;
 			switch(c)
 			{
 			case 'g':


### PR DESCRIPTION
* RDKEMW-6595: Fix coverity issue in dsAudio.c
* RDKEMW-6595: Fix coverity issues in dsAudio.c 

Coverity issue - Indefinite wait, BAD_CHECK_OF_WAIT_COND

* RDKEMW-6595: Ensure null termination in VideoOutputPort::setResolution func
* RDKEMW-6595: Fix uninitialized variable coverity err in dsVideoPort.c
* RDKEMW-6595: Fix Medium Impact coverity issue in devicesettings
* RDKEMW-6595: Fix COPY_INSTEAD_OF_MOVE coverity issues in devicesettings



---------