### PR TITLE
RDKEMW-4848: pass the proper handle to dsEnableHDCP

### DIFF
--- a/ds/videoOutputPortType.cpp
+++ b/ds/videoOutputPortType.cpp
@@ -220,7 +220,7 @@ void VideoOutputPortType::enabledHDCP(bool contentProtect , char *hdcpKey , size
     dsVideoPortType_t portType = device::Host::getInstance().isHDMIOutPortPresent()
                                  ? dsVIDEOPORT_TYPE_HDMI
                                  : dsVIDEOPORT_TYPE_INTERNAL;
-    ret = dsGetVideoPort(portType, &handle);
+    ret = dsGetVideoPort(portType, 0, &handle);
     if ((ret == dsERR_NONE) && (handle != -1)) {
         ret = dsEnableHDCP(handle, contentProtect, hdcpKey, keySize);
     } else {

--- a/ds/videoOutputPortType.cpp
+++ b/ds/videoOutputPortType.cpp
@@ -209,14 +209,24 @@ void VideoOutputPortType::enabledDTCP()
  */
 void VideoOutputPortType::enabledHDCP(bool contentProtect , char *hdcpKey , size_t keySize )
 {
-  	dsError_t ret = dsERR_NONE;
-    if (device::Host::getInstance().isHDMIOutPortPresent()){
-        ret = dsEnableHDCP(dsVIDEOPORT_TYPE_HDMI, contentProtect, hdcpKey, keySize);
+    dsError_t ret = dsERR_NONE;
+    intptr_t handle = -1;
+
+    if (!hdcpKey || keySize == 0) {
+        INT_ERROR("VideoOutputPortType::enabledHDCP: Invalid HDCP key or key size");
+        throw IllegalArgumentException();
     }
-    else{
-        ret = dsEnableHDCP(dsVIDEOPORT_TYPE_INTERNAL , contentProtect, hdcpKey, keySize);
+    // Assuming isHDMIOutPortPresent() will only be 'true' for TV profile devices
+    dsVideoPortType_t portType = device::Host::getInstance().isHDMIOutPortPresent()
+                                 ? dsVIDEOPORT_TYPE_HDMI
+                                 : dsVIDEOPORT_TYPE_INTERNAL;
+    ret = dsGetVideoPort(portType, &handle);
+    if ((ret == dsERR_NONE) && (handle != -1)) {
+        ret = dsEnableHDCP(handle, contentProtect, hdcpKey, keySize);
+    } else {
+        INT_ERROR("VideoOutputPortType::enabledHDCP: Error for type %d; error code=%d", portType, ret);
     }
-    
+
   	if (ret != dsERR_NONE)
   	{
   		throw IllegalArgumentException();

--- a/ds/videoOutputPortType.cpp
+++ b/ds/videoOutputPortType.cpp
@@ -212,10 +212,6 @@ void VideoOutputPortType::enabledHDCP(bool contentProtect , char *hdcpKey , size
     dsError_t ret = dsERR_NONE;
     intptr_t handle = -1;
 
-    if (!hdcpKey || keySize == 0) {
-        INT_ERROR("VideoOutputPortType::enabledHDCP: Invalid HDCP key or key size");
-        throw IllegalArgumentException();
-    }
     // Assuming isHDMIOutPortPresent() will only be 'true' for TV profile devices
     dsVideoPortType_t portType = device::Host::getInstance().isHDMIOutPortPresent()
                                  ? dsVIDEOPORT_TYPE_HDMI

--- a/ds/videoOutputPortType.cpp
+++ b/ds/videoOutputPortType.cpp
@@ -212,7 +212,7 @@ void VideoOutputPortType::enabledHDCP(bool contentProtect , char *hdcpKey , size
     dsError_t ret = dsERR_NONE;
     intptr_t handle = -1;
 
-    // Assuming isHDMIOutPortPresent() will only be 'true' for TV profile devices
+    // Assuming isHDMIOutPortPresent() will only be 'true' for Source devices
     dsVideoPortType_t portType = device::Host::getInstance().isHDMIOutPortPresent()
                                  ? dsVIDEOPORT_TYPE_HDMI
                                  : dsVIDEOPORT_TYPE_INTERNAL;


### PR DESCRIPTION
Reason for Change: Initially it was always giving handle 0 since HAL was handling prooper handle but https://github.com/rdkcentral/devicesettings/pull/79 introduced a bug by passing ENUM instead of valid handle. This change fixes it.