### PR TITLE
RDKEMW-16670: Fix for crash when reading EDID from STB

### DIFF
--- a/rpc/cli/dsHdmiIn.c
+++ b/rpc/cli/dsHdmiIn.c
@@ -269,7 +269,7 @@ dsError_t dsGetEDIDBytesInfo (dsHdmiInPort_t iHdmiPort, unsigned char *edid, int
                             (void *)&param,
                             sizeof(param));
 
-    if (IARM_RESULT_SUCCESS == rpcRet && param.eRet == dsERR_NONE && param->length > 0 && param->length <= MAX_EDID_BYTES_LEN)
+    if (IARM_RESULT_SUCCESS == rpcRet && param.result == dsERR_NONE && param.length > 0 && param.length <= MAX_EDID_BYTES_LEN)
     {
         *length = param.length;
         memcpy_s(edid, *length, param.edid, param.length);

--- a/rpc/cli/dsHdmiIn.c
+++ b/rpc/cli/dsHdmiIn.c
@@ -269,7 +269,7 @@ dsError_t dsGetEDIDBytesInfo (dsHdmiInPort_t iHdmiPort, unsigned char *edid, int
                             (void *)&param,
                             sizeof(param));
 
-    if (IARM_RESULT_SUCCESS == rpcRet)
+    if (IARM_RESULT_SUCCESS == rpcRet && param.eRet == dsERR_NONE && param->length > 0 && param->length <= MAX_EDID_BYTES_LEN)
     {
         *length = param.length;
         memcpy_s(edid, *length, param.edid, param.length);


### PR DESCRIPTION
Reason For Change: Fix for crash when reading EDID from STB
Test procedure : Compiled and Verified
version: patch
Priority: P1