### PR TITLE
RDKEMW-21885: write hdmi inprogress state

### DIFF
--- a/rpc/srv/dsVideoPort.c
+++ b/rpc/srv/dsVideoPort.c
@@ -1494,6 +1494,12 @@ void _dsHdcpCallback (intptr_t handle, dsHdcpStatus_t status)
 			_dsSyncHdmiStatus(DS_HDMI_TAG_HDCPVERSION, dsHDCP_VERSION_1X);
 		}
 	}
+	else
+	{
+		INT_INFO("Hdmi sync HDCP Protocol inprogress  new protocol status is : %d  new protocol verision is : %d  !!!!!!!! ..\r\n", _hdcpStatus ,dsHDCP_VERSION_1X);
+	       _dsSyncHdmiStatus(DS_HDMI_TAG_HDCPSTATUS, _hdcpStatus);
+	       _dsSyncHdmiStatus(DS_HDMI_TAG_HDCPVERSION, dsHDCP_VERSION_1X);
+	}
 	
 	IARM_Bus_BroadcastEvent(IARM_BUS_DSMGR_NAME,(IARM_EventId_t)IARM_BUS_DSMGR_EVENT_HDCP_STATUS,(void *)&hdcp_eventData, sizeof(hdcp_eventData));
 }


### PR DESCRIPTION
[RDKEMW-21885] : [8.4][ROGERS RTK IUV2/Alpaca DE]4K Linear Channel Playback Issues After Standby Resume